### PR TITLE
Add premises to cyclic lemmas generated from conditional case splits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> std::io::Result<()> {
   let mut non_cyclic_num_valid = 0;
   for raw_goal in parser_state.raw_goals.iter() {
     let (reductions, defns) =
-      parser_state.get_reductions_and_definitions(&raw_goal, raw_goal.local_rules.clone());
+      parser_state.get_reductions_and_definitions(raw_goal, raw_goal.local_rules.clone());
     let mut goal = Goal::top(
       &raw_goal.name,
       &raw_goal.equation,


### PR DESCRIPTION
We can always use a cyclic lemma generated before a regular case split, because the equality induced by the case split is enforced in the e-graph.

However, if we case split on a condition, any lemmas generated after that only are true when the condition is true (or false, depending on which branch of the case we are in).

[proof needed]

This PR collects premises generated from conditional case splits so that we do not unsoundly use any lemmas generated after the case split.